### PR TITLE
extend eslint configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,14 @@
         "commonjs": true,
         "es2021": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "eslint:recommended",
+        "eslint-config-standard",
+        "eslint-config-semistandard",
+        "plugin:import/recommended",
+        "plugin:n/recommended",
+        "plugin:promise/recommended"
+    ],
     "parserOptions": {
         "ecmaVersion": "latest"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "dev": "nodemon src/server.js",
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint . --ext .ts,.js, --fix --ignore-path .gitignore"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I always forget this part, but the plugins and styleguides and stuff have to all be explicitly enabled. 

I didn't make any changes to what you'd imported, so we can continue our separate discussion about styleguide

I also didn't check in any fixes for linter errors these plugins are highlighting, but I'll do a followup PR after this with all those little changes