### PR TITLE
Add port 3000 as a fallback in case not added to local env

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,29 +1,29 @@
-const path = require("node:path");
-const express = require("express");
+const path = require('node:path');
+const express = require('express');
 const app = express();
-const cors = require("cors");
-const favicon = require("express-favicon");
-const logger = require("morgan");
+const cors = require('cors');
+const favicon = require('express-favicon');
+const logger = require('morgan');
 
 // imports
-const testsRouter = require("./routes/testsRouter");
-const activitiesRouter = require("./routes/activitiesRouter");
+const testsRouter = require('./routes/testsRouter');
+const activitiesRouter = require('./routes/activitiesRouter');
 
-const { errorHandler, notFound } = require("./middleware/errorHandler");
+const { errorHandler, notFound } = require('./middleware/errorHandler');
 
 // middleware
 
 // we shall change the cors origin once the frontend is deployed
-app.use(cors({ origin: process.env.ORIGIN, optionsSuccessStatus: 200 }));
+app.use(cors({ origin: process.env.ORIGIN || "http://localhost:3000", optionsSuccessStatus: 200 }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use(logger("dev"));
-app.use(express.static("public"));
-app.use(favicon(path.join(__dirname, "/public/favicon.ico")));
+app.use(logger('dev'));
+app.use(express.static('public'));
+app.use(favicon(path.join(__dirname, '/public/favicon.ico')));
 
 // routes
-app.use("/api/v1", testsRouter);
-app.use("/api/v1/activities", activitiesRouter);
+app.use('/api/v1', testsRouter);
+app.use('/api/v1/activities', activitiesRouter);
 
 app.use(notFound);
 app.use(errorHandler);


### PR DESCRIPTION
### This PR resolves Issue

## Change Summary

- Update CORS requirement to use port 3000 as a fallback if it's not installed in local env 

## I Had Difficulty With

_Only added because I had a hard time finding how to get around the CORS error._
