### PR TITLE
add all team members as code owners [BE]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Angel and Darga will be auto-requested as reviewers by any non-draft PR
-# TODO add entire BE team
-* @angelkbrown @dargaCode
+# All team members will be automatically requested as code reviewers for any non-draft PR
+@angelkbrown
+@anniethewebcoder
+@catbus00
+@dargacode
+@marice-romero
+@msrezaie
+@victoria240


### PR DESCRIPTION
### This PR resolves #30 

## Change Summary
- Add all team members as code owners so we'll all be auto-requested to code review non-draft PRs