### PR TITLE
27: Add user model and account creation endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "express-favicon": "^2.0.4",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.0.1",
         "morgan": "^1.10.0",
         "validator": "^13.11.0"
@@ -669,6 +671,11 @@
         "node": ">=14.20.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -975,6 +982,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -1183,6 +1210,14 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2786,6 +2821,46 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -2837,11 +2912,46 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "express-favicon": "^2.0.4",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.0.1",
     "morgan": "^1.10.0",
     "validator": "^13.11.0"

--- a/src/Utilities/generateCookie.js
+++ b/src/Utilities/generateCookie.js
@@ -1,0 +1,10 @@
+const generateCookie = ({ res, token }) => {
+  const oneDay = 24 * 60 * 60 * 1000;
+  res.cookie("jwt", token, {
+    httpOnly: true,
+    expires: new Date(Date.now() + oneDay),
+    secure: process.env.PRODUCTION_ENV === "production",
+  });
+};
+
+module.exports = generateCookie;

--- a/src/app.js
+++ b/src/app.js
@@ -4,10 +4,12 @@ const app = express();
 const cors = require("cors");
 const favicon = require("express-favicon");
 const logger = require("morgan");
+const cookieParser = require("cookie-parser");
 
 // imports
 const testsRouter = require("./routes/testsRouter");
 const activitiesRouter = require("./routes/activitiesRouter");
+const authRouter = require("./routes/authRouter");
 
 const { errorHandler, notFound } = require("./middleware/errorHandler");
 
@@ -16,6 +18,7 @@ const { errorHandler, notFound } = require("./middleware/errorHandler");
 // we shall change the cors origin once the frontend is deployed
 app.use(cors({ origin: process.env.ORIGIN, optionsSuccessStatus: 200 }));
 app.use(express.json());
+app.use(cookieParser());
 app.use(express.urlencoded({ extended: false }));
 app.use(logger("dev"));
 app.use(express.static("public"));
@@ -24,6 +27,7 @@ app.use(favicon(path.join(__dirname, "/public/favicon.ico")));
 // routes
 app.use("/api/v1", testsRouter);
 app.use("/api/v1/activities", activitiesRouter);
+app.use("/api/v1/auth", authRouter);
 
 app.use(notFound);
 app.use(errorHandler);

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,0 +1,29 @@
+const User = require("../models/User");
+const generateCookie = require("../utilities/generateCookie");
+
+// @desc    creates a 'token cookie' and creates a new user
+// @route   POST /api/v1/auth/signup
+// @access  public
+const signup = async (req, res) => {
+  const { name, email, password } = req.body;
+
+  if (!email || !password || !name) {
+    res.status(400);
+    throw new Error("Please provide, name, email and password!");
+  } else if (await User.findOne({ email })) {
+    res.status(400);
+    throw new Error(`User with ${email} email already exists!`);
+  }
+
+  const user = await User.create({ name, email, password });
+  const token = user.createJWT();
+  generateCookie({ res, token });
+  res
+    .status(201)
+    .json({
+      msg: "Signed up successfully!",
+      user: { ...user._doc, password: undefined },
+    });
+};
+
+module.exports = { signup };

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,0 +1,44 @@
+const bcrypt = require("bcrypt");
+const mongoose = require("mongoose");
+const validator = require("validator");
+const jwt = require("jsonwebtoken");
+
+const userSchema = mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: [true, "please provide a name!"],
+    },
+    email: {
+      type: String,
+      required: [true, "please provide an email!"],
+      validate: {
+        validator: validator.isEmail,
+        message: "Please provide a valid email!",
+      },
+      unique: true,
+    },
+    password: {
+      type: String,
+      required: [true, "please provide a password!"],
+      minlength: [8, "password must be at least 8 characters long!"],
+      select: false,
+    },
+  },
+  { timestamps: true }
+);
+
+// Middlware function responsible for hashing the password using bcrypt
+userSchema.pre("save", async function () {
+  const salt = await bcrypt.genSalt();
+  this.password = await bcrypt.hash(this.password, salt);
+});
+
+// A User model method for creating a jwt token saving user's ID as its payload
+userSchema.methods.createJWT = function () {
+  return jwt.sign({ id: this._id }, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_LIFETIME,
+  });
+};
+
+module.exports = mongoose.model("User", userSchema);

--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const { signup } = require("../controllers/authController");
+
+// @route   POST /api/v1/auth/signup
+router.post("/signup", signup);
+
+module.exports = router;


### PR DESCRIPTION
### This PR resolves Issue [#27](https://github.com/Code-the-Dream-School/ee-prac-team2-back/issues/27)

## Change Summary

- A new `User` model is added with the following fields: `name`, `email`, and `password`
- Added two new packages: `jsonwebtoken` for storing user specific payload in an encrypted piece of data, and `cookie-parser` for parsing cookie data
- The User model is implemented with middleware/functions to handle: hashing of passwords using the `bcrypt` package, and creating a `jwt` token for storing user's ID for authorization
- A new `auth` controller has been implemented. For now only has one endpoint `/auth/signup` which handles the creation of a user
- A new directory `utilities` is added for storing files that provide specific tasks and functionalities
- Added `generateCookie` file in `utilities` for handling the creation and options of a cookie
- The authorization is currently being done by an `HTTP-Only` cookie, that stores user specific payload and is created and sent by the server to the client upon a successful authorization (signup/login)

## I Had Difficulty With

_In here, the implementation of the authorization logic is entirely done manually. There are node packages such as passport for performing the same thing, though I am not a big fan that particular package. Though if need be, or if @marice-romero feels comfortable using the passport package, we can modify the auth logic._
