### PR TITLE
53: Pull activities from https://boredapi.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.6.2",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -530,8 +531,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -543,6 +543,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -906,7 +916,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1132,7 +1141,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1984,6 +1992,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1997,7 +2024,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3801,6 +3827,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -5375,14 +5406,23 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5665,7 +5705,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5823,8 +5862,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6466,6 +6504,11 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -6479,7 +6522,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7784,6 +7826,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^1.6.2",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/src/controllers/activitiesController.js
+++ b/src/controllers/activitiesController.js
@@ -5,7 +5,7 @@ const Activity = require("../models/Activity");
 // @routes  GET /api/v1/activities
 // @access  public
 const getAllActivities = async (req, res) => {
-  const suggestedActivities = [];
+  let suggestedActivities = [];
 
   for (let i = 0; i < 3; i++) {
     const apiResponse = await axios.get(
@@ -13,8 +13,21 @@ const getAllActivities = async (req, res) => {
     );
     suggestedActivities.push(apiResponse.data);
   }
+  suggestedActivities = suggestedActivities.map((element) => ({
+    activity: element.activity,
+    type: element.type,
+  }));
+
+  console.log(suggestedActivities);
   const hardCodedActivities = await Activity.aggregate([
     { $sample: { size: 3 } },
+    {
+      $project: {
+        activity: 1,
+        type: 1,
+        _id: 0,
+      },
+    },
   ]);
 
   suggestedActivities.push(...hardCodedActivities);

--- a/src/controllers/activitiesController.js
+++ b/src/controllers/activitiesController.js
@@ -1,15 +1,28 @@
+const axios = require("axios");
 const Activity = require("../models/Activity");
 
 // @desc    Endpoint for fetching all activities
-// @route   GET /api/v1/activities
+// @routes  GET /api/v1/activities
 // @access  public
 const getAllActivities = async (req, res) => {
-  const response = await Activity.find().populate({
-    path: "vote",
-    populate: { path: "voters" },
-  });
+  const suggestedActivities = [];
 
-  return res.json({ count: response.length, activities: response });
+  for (let i = 0; i < 3; i++) {
+    const apiResponse = await axios.get(
+      `https://www.boredapi.com/api/activity?participants=${i + 1}`
+    );
+    suggestedActivities.push(apiResponse.data);
+  }
+  const hardCodedActivities = await Activity.aggregate([
+    { $sample: { size: 3 } },
+  ]);
+
+  suggestedActivities.push(...hardCodedActivities);
+
+  return res.json({
+    count: suggestedActivities.length,
+    activities: suggestedActivities,
+  });
 };
 
 // @desc    Endpoint for fetching a single activity

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -12,7 +12,7 @@ paths:
       tags:
         - Activities
       summary: Get All Activities
-      description: Endpoint for viewing all the activities
+      description: Endpoint for viewing all the activities. This endpoint returns a combination of activities, a total of 6 randomzied activity documents (3 from bored API and 3 from hard coded activities) will be returned.
       operationId: GetAllActivities
       parameters: []
       responses:
@@ -26,7 +26,13 @@ paths:
       summary: Create Activity
       description: Endpoint for creating an activity
       operationId: CreateActivity
-      parameters: []
+      parameters:
+        - name: dummy
+          in: query
+          required: false
+          description: With this query set to true, the activity resource will be saved in the dummy data model of activities (Activity). But if set to false or absent, an 'eventID' value will be required in the POST request body and the activity resource will be saved in the EventActivity data model.
+          schema:
+            type: boolean
       requestBody:
         description: ""
         content:
@@ -35,13 +41,13 @@ paths:
               allOf:
                 - $ref: "#/components/schemas/CreateActivityRequest"
                 - example:
-                    name: Soccer Day
-                    category: social
-                    description: A sports tournament event.
+                    eventID: 6574c51581ee2c66d25177c9
+                    activity: A volleyball tournament event
+                    type: sports.
             example:
-              name: Soccer Day
-              category: social
-              description: A sports tournament event.
+              eventID: 6574c51581ee2c66d25177c9
+              activity: A volleyball tournament event
+              type: sports.
         required: true
       responses:
         "201":
@@ -71,9 +77,9 @@ paths:
     delete:
       tags:
         - Activities
-      summary: Delete Activity
-      description: Endpoint for deleting an activity. Activity ID must be provided as a URL param!
-      operationId: DeleteActivity
+      summary: Delete Event Activity
+      description: Endpoint for deleting an event activity. Activity ID must be provided as a URL param!
+      operationId: DeleteEventActivity
       parameters: []
       responses:
         "200":
@@ -83,9 +89,9 @@ paths:
     put:
       tags:
         - Activities
-      summary: Update Activity
-      description: Endpoint for updating an activity. Activity ID must be provided as a URL param!
-      operationId: UpdateActivity
+      summary: Update Event Activity
+      description: Endpoint for updating an event activity. Activity ID must be provided as a URL param!
+      operationId: UpdateEventActivity
       parameters: []
       requestBody:
         description: ""
@@ -106,7 +112,7 @@ paths:
           description: ""
           headers: {}
       deprecated: false
-  /api/v1/votes/{activityID}:
+  /api/v1/activities/{activityID}/votes:
     parameters:
       - in: path
         name: activityID
@@ -116,10 +122,10 @@ paths:
         description: The activity resource id
     put:
       tags:
-        - Vote
-      summary: Update Activity Vote
-      description: Endpoint for updating (increase/decrease) vote count of an activity. A signed in user is required in order to access this route!
-      operationId: UpdateActivityVote
+        - Activities
+      summary: Update Event Activity Vote
+      description: Endpoint for updating (increase/decrease) vote count of an event activity. A signed in user is required in order to access this route!
+      operationId: UpdateEventActivityVote
       parameters: []
       responses:
         "200":
@@ -216,35 +222,35 @@ components:
     CreateActivityRequest:
       title: CreateActivityRequest
       required:
-        - name
-        - category
-        - description
+        - eventID
+        - activity
+        - type
       type: object
       properties:
-        name:
+        eventID:
           type: string
-        category:
+        activity:
           type: string
-        description:
+        type:
           type: string
       example:
-        name: Soccer Day
-        category: social
-        description: A sports tournament event.
+        eventID: 6574c51581ee2c66d25177c9
+        activity: A volleyball tournament event
+        type: sports.
     UpdateActivityRequest:
       title: UpdateActivityRequest
       required:
-        - name
-        - category
+        - activity
+        - type
       type: object
       properties:
-        name:
+        activity:
           type: string
-        category:
+        type:
           type: string
       example:
-        name: Hiking
-        category: relaxing
+        activity: Hiking
+        type: relaxing
     SignupUserRequest:
       title: SignupUserRequest
       required:


### PR DESCRIPTION
### Attached Issue
This PR resolves #53 

## Change Summary
- Installed Axios `npm` package. This package is primarily used for fetching data from the Bored API's URL.
- The activities data coming from BoredAPI are combined with the hard coded activities. A max limit of 6 resources is set by default.
- Accessing the `/api/v1/activities` route will return 6 randomized activity documents.