### PR TITLE
Add attribute to CORS to permit credentials 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -31,6 +31,14 @@ app.use(
     optionsSuccessStatus: 200,
   })
 );
+app.use(function(req, res, next) {
+    res.header('Access-Control-Allow-Credentials', true);
+    res.header(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requested-With, Content-Type, Accept'
+    );
+    next();
+});
 app.use(express.json());
 app.use(cookieParser());
 app.use(express.urlencoded({ extended: false }));

--- a/src/app.js
+++ b/src/app.js
@@ -31,14 +31,6 @@ app.use(
     optionsSuccessStatus: 200,
   })
 );
-app.use(function(req, res, next) {
-    res.header('Access-Control-Allow-Credentials', true);
-    res.header(
-        'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept'
-    );
-    next();
-});
 app.use(express.json());
 app.use(cookieParser());
 app.use(express.urlencoded({ extended: false }));

--- a/src/app.js
+++ b/src/app.js
@@ -27,6 +27,7 @@ const { authenticateUser } = require("./middleware/authHandler");
 app.use(
   cors({
     origin: process.env.ORIGIN || "http://localhost:3000",
+    credentials: true,
     optionsSuccessStatus: 200,
   })
 );

--- a/src/utils/generateCookie.js
+++ b/src/utils/generateCookie.js
@@ -4,6 +4,7 @@ const generateCookie = ({ res, token }) => {
     httpOnly: true,
     expires: new Date(Date.now() + oneDay),
     secure: process.env.PRODUCTION_ENV === "production",
+    sameSite: false
   });
 };
 


### PR DESCRIPTION
### Attached Issue
This PR resolves #62

## Change Summary
Added to CORS config to allow CORS requests to include credentials (I think? Not even sure now which part this fixed.) Also added SameSite: false to the jwt cookie to ensure that it can be set for other origins.

## I Had Difficulty With
I looked past a typo for way too long and this took way longer than it should as a result! I guess this is why it's not good to work while tired. 😅 
