### PR TITLE
61: Please add Activity IDs to /activities response JSON

### DIFF
--- a/src/controllers/activitiesController.js
+++ b/src/controllers/activitiesController.js
@@ -16,6 +16,7 @@ const getAllActivities = async (req, res) => {
     suggestedActivities.push(apiResponse.data);
   }
   suggestedActivities = suggestedActivities.map((element) => ({
+    _id: element.key,
     activity: element.activity,
     type: element.type,
   }));
@@ -26,7 +27,7 @@ const getAllActivities = async (req, res) => {
       $project: {
         activity: 1,
         type: 1,
-        _id: 0,
+        _id: 1,
       },
     },
   ]);


### PR DESCRIPTION
### Attached Issue
This PR resolves [#61](https://github.com/Code-the-Dream-School/ee-prac-team2-back/issues/61)

## Change Summary
- Endpoint responsible for fetching data from bored API did not include a `_id` field in the returned documents, now it does.
