### PR TITLE
process ONLY staged files with lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,17 @@
     "test": "mocha"
   },
   "lint-staged": {
-    "*.{css,md,json}": [
-      "npm run format"
+    "*": [
+      "prettier --ignore-unknown --write"
     ],
-    "*.ts?(x)": [
-      "npm run format"
+    "*.{ts, js}": [
+      "prettier --write",
+      "eslint --fix"
     ],
-    "package.json": "npx sort-package-json"
+    "package.json": [
+      "prettier --write",
+      "npx sort-package-json"
+    ]
   },
   "dependencies": {
     "axios": "^1.6.2",


### PR DESCRIPTION
### Attached Issue

This PR resolves #74 

## Change Summary
Commit scripts were taking a hugely longer time than they were supposed to, because I was running scripts (eg `npm run lint`) which are hardcoded to affect ALL files in the repo